### PR TITLE
fix: content filters block

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ object({
       }))
     }))
     deployments = optional(map(object({
-      name = optional(string)
+      name                       = optional(string)
+      dynamic_throttling_enabled = optional(string)
       model = object({
         format  = string
         name    = string
@@ -111,13 +112,13 @@ object({
       base_policy_name = string
       mode             = optional(string)
       tags             = optional(map(string))
-      content_filter = object({
+      content_filters = map(object({
         name               = string
         filter_enabled     = bool
         block_enabled      = bool
         severity_threshold = string
         source             = string
-      })
+      }))
     })))
   })
 ```

--- a/examples/policies/main.tf
+++ b/examples/policies/main.tf
@@ -46,12 +46,21 @@ module "cognitiveservices" {
     policies = {
       example = {
         base_policy_name = "Microsoft.Default"
-        content_filter = {
-          name               = "Hate"
-          filter_enabled     = true
-          block_enabled      = true
-          severity_threshold = "High"
-          source             = "Prompt"
+        content_filters = {
+          filter_hate = {
+            name               = "Hate"
+            filter_enabled     = true
+            block_enabled      = true
+            severity_threshold = "High"
+            source             = "Prompt"
+          }
+          filter_violence = {
+            name               = "Violence"
+            filter_enabled     = true
+            block_enabled      = true
+            severity_threshold = "Low"
+            source             = "Completion"
+          }
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -134,12 +134,15 @@ resource "azurerm_cognitive_account_rai_policy" "policy" {
   cognitive_account_id = azurerm_cognitive_account.cognitive_account.id
   base_policy_name     = each.value.base_policy_name
 
-  content_filter {
-    name               = each.value.content_filter.name
-    filter_enabled     = each.value.content_filter.filter_enabled
-    block_enabled      = each.value.content_filter.block_enabled
-    severity_threshold = each.value.content_filter.severity_threshold
-    source             = each.value.content_filter.source
+  dynamic "content_filter" {
+    for_each = each.value.content_filters
+    content {
+      name               = content_filter.value.name
+      filter_enabled     = content_filter.value.filter_enabled
+      block_enabled      = content_filter.value.block_enabled
+      severity_threshold = content_filter.value.severity_threshold
+      source             = content_filter.value.source
+    }
   }
 
   tags = coalesce(

--- a/variables.tf
+++ b/variables.tf
@@ -65,13 +65,13 @@ variable "account" {
       base_policy_name = string
       mode             = optional(string)
       tags             = optional(map(string))
-      content_filter = object({
+      content_filters = map(object({
         name               = string
         filter_enabled     = bool
         block_enabled      = bool
         severity_threshold = string
         source             = string
-      })
+      }))
     })))
   })
 


### PR DESCRIPTION
## Description

Documentation of AzureRM is incorrect: https://github.com/hashicorp/terraform-provider-azurerm/issues/30865
Therefore, we added the content_filter as single block, but multiple content_filters can actually be set for 1 policy. 


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes 
